### PR TITLE
Spring Security를 이용한 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests().requestMatchers(
+                        new AntPathRequestMatcher("/**")).permitAll()
+                .and()
+                .csrf().ignoringRequestMatchers(
+                        new AntPathRequestMatcher("/api/v1/**"))
+        ;
+        return http.build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/demo/database/User.java
+++ b/src/main/java/com/example/demo/database/User.java
@@ -1,6 +1,9 @@
 package com.example.demo.database;
 
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -8,6 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "user")
 @Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
     @Id
     @GeneratedValue
@@ -21,4 +25,11 @@ public class User {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @Builder
+    public User(String username, String password, LocalDateTime createdAt) {
+        this.username = username;
+        this.password = password;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/example/demo/database/User.java
+++ b/src/main/java/com/example/demo/database/User.java
@@ -1,9 +1,6 @@
 package com.example.demo.database;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -11,25 +8,27 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "user")
 @Data
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
     @Id
     @GeneratedValue
     private Integer id;
 
     @Column(length = 16)
+    @NonNull
     private String username;
 
     @Column(length = 64)
+    @NonNull
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Builder
-    public User(String username, String password, LocalDateTime createdAt) {
-        this.username = username;
-        this.password = password;
-        this.createdAt = createdAt;
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/demo/database/User.java
+++ b/src/main/java/com/example/demo/database/User.java
@@ -20,7 +20,7 @@ public class User {
     @Column(length = 16)
     private String username;
 
-    @Column(length = 24)
+    @Column(length = 64)
     private String password;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/demo/microservice/registration/RegistrationUserService.java
+++ b/src/main/java/com/example/demo/microservice/registration/RegistrationUserService.java
@@ -3,6 +3,7 @@ package com.example.demo.microservice.registration;
 import com.example.demo.database.User;
 import com.example.demo.database.UserRepository;
 import com.example.demo.microservice.registration.dto.UserRequestDTO;
+import com.example.demo.microservice.registration.exception.UsernameAlreadyExistException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -13,17 +14,21 @@ public class RegistrationUserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public void create(UserRequestDTO userRequestDTO) throws Exception {
-        validateDuplicateMember(userRequestDTO);
+    public void create(UserRequestDTO userRequestDTO) throws IllegalArgumentException, UsernameAlreadyExistException {
+        validate(userRequestDTO);
         User user = userRequestDTO.toEntity();
         user.setPassword(passwordEncoder.encode(user.getPassword()));
 
         userRepository.save(user);
     }
 
-    private void validateDuplicateMember(UserRequestDTO userDTO) {
+    private void validate(UserRequestDTO userDTO) throws IllegalArgumentException, UsernameAlreadyExistException {
+        if (userDTO.getUsername().isBlank() || userDTO.getPassword().isBlank()) {
+            throw new IllegalArgumentException();
+        }
         if (userRepository.findByUsername(userDTO.getUsername()).isPresent()) {
-            throw new IllegalStateException("이미 존재하는 회원입니다.");
+            throw new UsernameAlreadyExistException();
         }
     }
+
 }

--- a/src/main/java/com/example/demo/microservice/registration/RegistrationUserService.java
+++ b/src/main/java/com/example/demo/microservice/registration/RegistrationUserService.java
@@ -1,0 +1,29 @@
+package com.example.demo.microservice.registration;
+
+import com.example.demo.database.User;
+import com.example.demo.database.UserRepository;
+import com.example.demo.microservice.registration.dto.UserRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RegistrationUserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void create(UserRequestDTO userRequestDTO) throws Exception {
+        validateDuplicateMember(userRequestDTO);
+        User user = userRequestDTO.toEntity();
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+
+        userRepository.save(user);
+    }
+
+    private void validateDuplicateMember(UserRequestDTO userDTO) {
+        if (userRepository.findByUsername(userDTO.getUsername()).isPresent()) {
+            throw new IllegalStateException("이미 존재하는 회원입니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/demo/microservice/registration/UserController.java
+++ b/src/main/java/com/example/demo/microservice/registration/UserController.java
@@ -1,21 +1,25 @@
 package com.example.demo.microservice.registration;
 
 import com.example.demo.microservice.registration.dto.UserRequestDTO;
+import com.example.demo.microservice.registration.exception.UsernameAlreadyExistException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/registration")
 public class UserController {
-    @Autowired
-    RegistrationUserService registrationUserService;
+    private final RegistrationUserService registrationUserService;
 
     @PostMapping("/signup")
-    @ResponseStatus(HttpStatus.OK)
-    public void signUp(@RequestBody UserRequestDTO userRequestDTO) throws Exception {
-        registrationUserService.create(userRequestDTO);
+    public ResponseEntity<String> signUp(@RequestBody UserRequestDTO userRequestDTO) {
+        try {
+            registrationUserService.create(userRequestDTO);
+            return ResponseEntity.status(HttpStatus.CREATED).body(null);
+        } catch (IllegalArgumentException | UsernameAlreadyExistException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
     }
 }

--- a/src/main/java/com/example/demo/microservice/registration/UserController.java
+++ b/src/main/java/com/example/demo/microservice/registration/UserController.java
@@ -1,0 +1,21 @@
+package com.example.demo.microservice.registration;
+
+import com.example.demo.microservice.registration.dto.UserRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/registration")
+public class UserController {
+    @Autowired
+    RegistrationUserService registrationUserService;
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.OK)
+    public void signUp(@RequestBody UserRequestDTO userRequestDTO) throws Exception {
+        registrationUserService.create(userRequestDTO);
+    }
+}

--- a/src/main/java/com/example/demo/microservice/registration/dto/UserRequestDTO.java
+++ b/src/main/java/com/example/demo/microservice/registration/dto/UserRequestDTO.java
@@ -1,0 +1,24 @@
+package com.example.demo.microservice.registration.dto;
+
+import com.example.demo.database.User;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class UserRequestDTO {
+    @NonNull
+    private String username;
+    @NonNull
+    private String password;
+
+    public User toEntity() {
+        return User.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/microservice/registration/dto/UserResponseDTO.java
+++ b/src/main/java/com/example/demo/microservice/registration/dto/UserResponseDTO.java
@@ -1,0 +1,19 @@
+package com.example.demo.microservice.registration.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class UserResponseDTO {
+    @NonNull
+    private String username;
+    @NonNull
+    private String password;
+    @NonNull
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/demo/microservice/registration/exception/UsernameAlreadyExistException.java
+++ b/src/main/java/com/example/demo/microservice/registration/exception/UsernameAlreadyExistException.java
@@ -1,0 +1,4 @@
+package com.example.demo.microservice.registration.exception;
+
+public class UsernameAlreadyExistException extends Exception {
+}


### PR DESCRIPTION
## Spring Security

회원가입시 비밀번호를 직접 저장 하는 방식은 보안에 취약하기 때문에 암호화를 하여 저장하는 방식으로 구현.
비밀번호 암호화를 위하여 Spring Security를 사용함.  
WebsecurityConfigureradapter가 Deprecated되었기 때문에 공식문서에서 권장하는 방식으로 SecurityFilterChain을 사용함.

## User

암호환된 password길이가 기존 크기인 24보다 길기 때문에  크기를 64로 변경함

## RegistrationUserService

UserRequestDTO를 통해 얻은 사용자 정보를 암호화 한 뒤 UserRepository를 통해 저장함.

## UserRequestDTO

데이터 교환을 위해 사용하는 DTO

## UserResponseDTO

회원가입 구현 시 사용하진 않지만 추가 기능 설정 대비하여 생성한 파일

## UserController

회원가입 뿐만 아니라 수정이나 조회를 대비하여 UserController라는 이름을 사용함.
추가 논의 필요

## 회원가입 API 테스트
![회원가입api](https://user-images.githubusercontent.com/85729858/212822981-82321de5-315c-454b-a3fe-eb70e81fc874.png)

## DB에 저장된 모습
![db확인](https://user-images.githubusercontent.com/85729858/212823146-c0bf7c86-0195-48db-a914-adf2d67ed54a.png)

